### PR TITLE
Fix Symfony 6.2 deprecations: AsMessageHandler + validator tweaks

### DIFF
--- a/console/src/Analytics/Consumer/BuildWebsiteSessionsHandler.php
+++ b/console/src/Analytics/Consumer/BuildWebsiteSessionsHandler.php
@@ -8,7 +8,7 @@ use App\Entity\Project;
 use App\Repository\Analytics\Website\PageViewRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -19,7 +19,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * the original page views data and calls itself recursively until
  * all sessions for this project are consumed.
  */
-final class BuildWebsiteSessionsHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class BuildWebsiteSessionsHandler
 {
     private EntityManagerInterface $em;
     private PageViewRepository $pageViewRepo;

--- a/console/src/Analytics/Consumer/ClearWebsiteSessionsHandler.php
+++ b/console/src/Analytics/Consumer/ClearWebsiteSessionsHandler.php
@@ -6,12 +6,13 @@ use App\Entity\Project;
 use App\Repository\Analytics\Website\SessionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Clear sessions stats older than 3 years.
  */
-final class ClearWebsiteSessionsHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class ClearWebsiteSessionsHandler
 {
     private EntityManagerInterface $em;
     private SessionRepository $repo;

--- a/console/src/Billing/Invoice/GenerateInvoicePdfHandler.php
+++ b/console/src/Billing/Invoice/GenerateInvoicePdfHandler.php
@@ -9,9 +9,10 @@ use App\Mailer\PlatformMailer;
 use App\Repository\Billing\OrderRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class GenerateInvoicePdfHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class GenerateInvoicePdfHandler
 {
     private OrderRepository $orderRepository;
     private PdfGenerator $pdfGenerator;

--- a/console/src/Billing/Invoice/GenerateQuotePdfHandler.php
+++ b/console/src/Billing/Invoice/GenerateQuotePdfHandler.php
@@ -9,9 +9,10 @@ use App\Mailer\PlatformMailer;
 use App\Repository\Billing\QuoteRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class GenerateQuotePdfHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class GenerateQuotePdfHandler
 {
     private QuoteRepository $repository;
     private PdfGenerator $pdfGenerator;

--- a/console/src/Bridge/Integromat/Consumer/IntegromatWebhookHandler.php
+++ b/console/src/Bridge/Integromat/Consumer/IntegromatWebhookHandler.php
@@ -4,10 +4,11 @@ namespace App\Bridge\Integromat\Consumer;
 
 use App\Repository\Integration\IntegromatWebhookRepository;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class IntegromatWebhookHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class IntegromatWebhookHandler
 {
     private HttpClientInterface $httpClient;
     private IntegromatWebhookRepository $repository;

--- a/console/src/Bridge/Postmark/Consumer/PostmarkHandler.php
+++ b/console/src/Bridge/Postmark/Consumer/PostmarkHandler.php
@@ -4,9 +4,10 @@ namespace App\Bridge\Postmark\Consumer;
 
 use App\Bridge\Postmark\PostmarkInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class PostmarkHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class PostmarkHandler
 {
     private PostmarkInterface $postmark;
     private LoggerInterface $logger;

--- a/console/src/Bridge/Quorum/Consumer/QuorumHandler.php
+++ b/console/src/Bridge/Quorum/Consumer/QuorumHandler.php
@@ -3,10 +3,11 @@
 namespace App\Bridge\Quorum\Consumer;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class QuorumHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class QuorumHandler
 {
     private HttpClientInterface $httpClient;
     private LoggerInterface $logger;

--- a/console/src/Bridge/Revue/Consumer/RevueSyncHandler.php
+++ b/console/src/Bridge/Revue/Consumer/RevueSyncHandler.php
@@ -7,10 +7,11 @@ use App\Api\Persister\ContactApiPersister;
 use App\Bridge\Revue\RevueInterface;
 use App\Entity\Integration\RevueAccount;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-final class RevueSyncHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class RevueSyncHandler
 {
     private EntityManagerInterface $em;
     private RevueInterface $revue;

--- a/console/src/Bridge/Sendgrid/Consumer/SendgridHandler.php
+++ b/console/src/Bridge/Sendgrid/Consumer/SendgridHandler.php
@@ -4,9 +4,10 @@ namespace App\Bridge\Sendgrid\Consumer;
 
 use App\Bridge\Sendgrid\SendgridInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class SendgridHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendgridHandler
 {
     private SendgridInterface $sendgrid;
     private LoggerInterface $logger;

--- a/console/src/Bridge/Spallian/Consumer/SpallianHandler.php
+++ b/console/src/Bridge/Spallian/Consumer/SpallianHandler.php
@@ -3,10 +3,11 @@
 namespace App\Bridge\Spallian\Consumer;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class SpallianHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SpallianHandler
 {
     private HttpClientInterface $httpClient;
     private LoggerInterface $logger;

--- a/console/src/Bridge/Twilio/Consumer/TwilioHandler.php
+++ b/console/src/Bridge/Twilio/Consumer/TwilioHandler.php
@@ -5,9 +5,10 @@ namespace App\Bridge\Twilio\Consumer;
 use App\Bridge\Twilio\Model\Personalization;
 use App\Bridge\Twilio\TwilioInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class TwilioHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class TwilioHandler
 {
     private TwilioInterface $twilio;
     private LoggerInterface $logger;

--- a/console/src/Community/Consumer/CreateEmailingCampaignBatchesHandler.php
+++ b/console/src/Community/Consumer/CreateEmailingCampaignBatchesHandler.php
@@ -13,14 +13,15 @@ use App\Repository\Community\EmailingCampaignRepository;
 use App\Util\PhoneNumber;
 use App\Util\Uid;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Uid\Uuid;
 
 /*
  * Resolve the filters of a given campaign, create entites for each message
  * and send the batch messages through a different consumer.
  */
-final class CreateEmailingCampaignBatchesHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class CreateEmailingCampaignBatchesHandler
 {
     public function __construct(
         private readonly EmailingCampaignRepository $campaignRepository,

--- a/console/src/Community/Consumer/CreateTextingCampaignBatchesHandler.php
+++ b/console/src/Community/Consumer/CreateTextingCampaignBatchesHandler.php
@@ -9,7 +9,7 @@ use App\Repository\Community\TextingCampaignRepository;
 use App\Util\PhoneNumber;
 use App\Util\Uid;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -17,7 +17,8 @@ use Symfony\Component\Uid\Uuid;
  * Resolve the filters of a given campaign, create entities for each message
  * and send the batch messages through a different consumer.
  */
-final class CreateTextingCampaignBatchesHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class CreateTextingCampaignBatchesHandler
 {
     private TextingCampaignRepository $campaignRepository;
     private TextingCampaignMessageRepository $messageRepository;

--- a/console/src/Community/Consumer/SendEmailingCampaignHandler.php
+++ b/console/src/Community/Consumer/SendEmailingCampaignHandler.php
@@ -7,14 +7,15 @@ use App\Repository\Community\EmailingCampaignMessageRepository;
 use App\Repository\Community\EmailingCampaignRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Resolve the filters of a given campaign, create entites for each message
  * and send the batch messages through a different consumer.
  */
-final class SendEmailingCampaignHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendEmailingCampaignHandler
 {
     private EntityManagerInterface $em;
     private EmailingCampaignRepository $campaignRepository;

--- a/console/src/Community/Consumer/SendMailchimpEmailingCampaignHandler.php
+++ b/console/src/Community/Consumer/SendMailchimpEmailingCampaignHandler.php
@@ -9,12 +9,13 @@ use App\Repository\Community\EmailingCampaignMessageRepository;
 use App\Repository\Community\EmailingCampaignRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Send a given email campaign through Mailchimp.
  */
-final class SendMailchimpEmailingCampaignHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendMailchimpEmailingCampaignHandler
 {
     private EntityManagerInterface $em;
     private EmailingCampaignRepository $campaignRepository;

--- a/console/src/Community/Consumer/SendTextingCampaignHandler.php
+++ b/console/src/Community/Consumer/SendTextingCampaignHandler.php
@@ -7,14 +7,15 @@ use App\Repository\Community\TextingCampaignMessageRepository;
 use App\Repository\Community\TextingCampaignRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Resolve the filters of a given campaign, create entites for each message
  * and send the batch messages through a different consumer.
  */
-final class SendTextingCampaignHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendTextingCampaignHandler
 {
     private EntityManagerInterface $em;
     private TextingCampaignRepository $campaignRepository;

--- a/console/src/Community/Consumer/StartPhoningCampaignHandler.php
+++ b/console/src/Community/Consumer/StartPhoningCampaignHandler.php
@@ -7,12 +7,13 @@ use App\Repository\Community\PhoningCampaignRepository;
 use App\Repository\Community\PhoningCampaignTargetRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Resolve the filters of a given campaign and create entites for each target.
  */
-final class StartPhoningCampaignHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class StartPhoningCampaignHandler
 {
     private EntityManagerInterface $em;
     private PhoningCampaignRepository $campaignRepository;

--- a/console/src/Community/ImportExport/Consumer/ExportEmailingCampaignHandler.php
+++ b/console/src/Community/ImportExport/Consumer/ExportEmailingCampaignHandler.php
@@ -10,10 +10,11 @@ use App\Repository\Community\EmailingCampaignRepository;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\String\Slugger\SluggerInterface;
 
-final class ExportEmailingCampaignHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class ExportEmailingCampaignHandler
 {
     private EmailingCampaignRepository $repository;
     private SluggerInterface $slugger;

--- a/console/src/Community/ImportExport/Consumer/ExportHandler.php
+++ b/console/src/Community/ImportExport/Consumer/ExportHandler.php
@@ -11,10 +11,11 @@ use App\Repository\OrganizationRepository;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
-final class ExportHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class ExportHandler
 {
     private OrganizationRepository $orgaRepository;
     private ContactRepository $contactRepository;

--- a/console/src/Community/ImportExport/Consumer/ImportHandler.php
+++ b/console/src/Community/ImportExport/Consumer/ImportHandler.php
@@ -19,10 +19,9 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\String\Slugger\SluggerInterface;
+use Symfony\Component\String\UnicodeString;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Component\String\UnicodeString;
 
 /**
  * Process import files.

--- a/console/src/Community/PostmarkMailFactory.php
+++ b/console/src/Community/PostmarkMailFactory.php
@@ -6,10 +6,9 @@ use App\Bridge\Postmark\Model\Mail;
 use App\Bridge\Postmark\Model\Personalization;
 use App\Bridge\Sendgrid\Model\Recipient;
 use App\Entity\Community\EmailingCampaign;
+use Twig\Environment;
 
 use function Symfony\Component\String\u;
-
-use Twig\Environment;
 
 class PostmarkMailFactory
 {

--- a/console/src/Community/SendgridMailFactory.php
+++ b/console/src/Community/SendgridMailFactory.php
@@ -11,10 +11,9 @@ use SendGrid\Mail\Header;
 use SendGrid\Mail\Mail;
 use SendGrid\Mail\To;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
 
 use function Symfony\Component\String\u;
-
-use Twig\Environment;
 
 class SendgridMailFactory
 {

--- a/console/src/Community/Webhook/SendgridWebhookHandler.php
+++ b/console/src/Community/Webhook/SendgridWebhookHandler.php
@@ -8,9 +8,10 @@ use App\Repository\Community\EmailingCampaignMessageRepository;
 use App\Util\Json;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class SendgridWebhookHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendgridWebhookHandler
 {
     private SendgridInterface $sendgrid;
     private EmailingCampaignMessageRepository $repository;

--- a/console/src/Community/Webhook/TwilioWebhookHandler.php
+++ b/console/src/Community/Webhook/TwilioWebhookHandler.php
@@ -7,9 +7,10 @@ use App\Entity\Community\TextingCampaignMessage;
 use App\Repository\Community\TextingCampaignMessageRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class TwilioWebhookHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class TwilioWebhookHandler
 {
     private TwilioInterface $twilio;
     private TextingCampaignMessageRepository $repository;

--- a/console/src/Community/Webhook/WingsWebhookHandler.php
+++ b/console/src/Community/Webhook/WingsWebhookHandler.php
@@ -5,9 +5,10 @@ namespace App\Community\Webhook;
 use App\Api\Model\ContactApiData;
 use App\Api\Persister\ContactApiPersister;
 use App\Repository\ProjectRepository;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class WingsWebhookHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class WingsWebhookHandler
 {
     public function __construct(
         private ProjectRepository $projectRepository,

--- a/console/src/Entity/Community/Contact.php
+++ b/console/src/Entity/Community/Contact.php
@@ -25,10 +25,9 @@ use libphonenumber\PhoneNumber as PhoneNumberModel;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\Uid\Uuid;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: ContactRepository::class)]
 #[ORM\Table('community_contacts', uniqueConstraints: [

--- a/console/src/Entity/Community/Tag.php
+++ b/console/src/Entity/Community/Tag.php
@@ -10,10 +10,9 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\Validator\Constraints as Assert;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: TagRepository::class)]
 #[ORM\Table('community_tags', uniqueConstraints: [

--- a/console/src/Entity/Theme/ProjectAsset.php
+++ b/console/src/Entity/Theme/ProjectAsset.php
@@ -10,10 +10,9 @@ use App\Util\Uid;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\Uid\Uuid;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: ProjectAssetRepository::class)]
 #[ORM\Table('projects_assets')]

--- a/console/src/Entity/Theme/WebsiteThemeAsset.php
+++ b/console/src/Entity/Theme/WebsiteThemeAsset.php
@@ -9,10 +9,9 @@ use App\Util\Uid;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\Uid\Uuid;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: WebsiteThemeAssetRepository::class)]
 #[ORM\Table('website_themes_assets')]

--- a/console/src/Entity/User.php
+++ b/console/src/Entity/User.php
@@ -20,10 +20,9 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Component\Uid\Uuid;
 
 /**
  * A user is a person having access to the Console.

--- a/console/src/Entity/Website/Document.php
+++ b/console/src/Entity/Website/Document.php
@@ -10,10 +10,9 @@ use App\Repository\Website\DocumentRepository;
 use App\Util\Uid;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\Uid\Uuid;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Component\Uid\Uuid;
 
 #[ORM\Entity(repositoryClass: DocumentRepository::class)]
 #[ORM\Table('website_documents')]

--- a/console/src/Proxy/Consumer/CloudflareCheckDomainHandler.php
+++ b/console/src/Proxy/Consumer/CloudflareCheckDomainHandler.php
@@ -2,12 +2,13 @@
 
 namespace App\Proxy\Consumer;
 
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Check the status of a domain on Cloudflare and triggers additional configuration when it's ready.
  */
-final class CloudflareCheckDomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class CloudflareCheckDomainHandler
 {
     use DomainHandlerTrait;
 

--- a/console/src/Proxy/Consumer/CloudflareCreateDomainHandler.php
+++ b/console/src/Proxy/Consumer/CloudflareCreateDomainHandler.php
@@ -2,12 +2,13 @@
 
 namespace App\Proxy\Consumer;
 
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Create a domain on Cloudflare.
  */
-final class CloudflareCreateDomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class CloudflareCreateDomainHandler
 {
     use DomainHandlerTrait;
 

--- a/console/src/Proxy/Consumer/CloudflareProvisionDomainHandler.php
+++ b/console/src/Proxy/Consumer/CloudflareProvisionDomainHandler.php
@@ -2,12 +2,13 @@
 
 namespace App\Proxy\Consumer;
 
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Provision records for a domain on Cloudflare.
  */
-final class CloudflareProvisionDomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class CloudflareProvisionDomainHandler
 {
     use DomainHandlerTrait;
 

--- a/console/src/Proxy/Consumer/ConfigureTrialSubdomainHandler.php
+++ b/console/src/Proxy/Consumer/ConfigureTrialSubdomainHandler.php
@@ -3,9 +3,10 @@
 namespace App\Proxy\Consumer;
 
 use App\Bridge\Cloudflare\CloudflareInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class ConfigureTrialSubdomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class ConfigureTrialSubdomainHandler
 {
     private CloudflareInterface $cloudflare;
 

--- a/console/src/Proxy/Consumer/PostmarkCheckDomainHandler.php
+++ b/console/src/Proxy/Consumer/PostmarkCheckDomainHandler.php
@@ -2,12 +2,13 @@
 
 namespace App\Proxy\Consumer;
 
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Check a domain's status on Postmark.
  */
-final class PostmarkCheckDomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class PostmarkCheckDomainHandler
 {
     use DomainHandlerTrait;
 

--- a/console/src/Proxy/Consumer/PostmarkConfigureDomainHandler.php
+++ b/console/src/Proxy/Consumer/PostmarkConfigureDomainHandler.php
@@ -3,12 +3,13 @@
 namespace App\Proxy\Consumer;
 
 use Postmark\Models\PostmarkException;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Add a domain to Postmark.
  */
-final class PostmarkConfigureDomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class PostmarkConfigureDomainHandler
 {
     use DomainHandlerTrait;
 

--- a/console/src/Proxy/Consumer/SendgridCheckDomainHandler.php
+++ b/console/src/Proxy/Consumer/SendgridCheckDomainHandler.php
@@ -2,12 +2,13 @@
 
 namespace App\Proxy\Consumer;
 
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Check a domain's status on Sendgrid.
  */
-final class SendgridCheckDomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendgridCheckDomainHandler
 {
     use DomainHandlerTrait;
 

--- a/console/src/Proxy/Consumer/SendgridConfigureDomainHandler.php
+++ b/console/src/Proxy/Consumer/SendgridConfigureDomainHandler.php
@@ -4,12 +4,13 @@ namespace App\Proxy\Consumer;
 
 use App\Entity\Domain;
 use App\Entity\Model\SendgridDomainConfig;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * Add a domain to Sendgrid.
  */
-final class SendgridConfigureDomainHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SendgridConfigureDomainHandler
 {
     use DomainHandlerTrait;
 

--- a/console/src/Search/Consumer/AbstractCrmBatchHandler.php
+++ b/console/src/Search/Consumer/AbstractCrmBatchHandler.php
@@ -7,9 +7,8 @@ use App\Entity\Organization;
 use App\Repository\OrganizationRepository;
 use App\Repository\Platform\JobRepository;
 use App\Search\Model\BatchRequest;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 
-abstract class AbstractCrmBatchHandler implements MessageHandlerInterface
+abstract class AbstractCrmBatchHandler
 {
     private MeilisearchInterface $meilisearch;
     private OrganizationRepository $organizationRepository;

--- a/console/src/Search/Consumer/AddTagCrmBatchHandler.php
+++ b/console/src/Search/Consumer/AddTagCrmBatchHandler.php
@@ -5,7 +5,9 @@ namespace App\Search\Consumer;
 use App\Repository\Community\TagRepository;
 use App\Search\CrmIndexer;
 use App\Search\Model\BatchRequest;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler]
 final class AddTagCrmBatchHandler extends AbstractCrmBatchHandler
 {
     public function __construct(

--- a/console/src/Search/Consumer/ExportCrmBatchHandler.php
+++ b/console/src/Search/Consumer/ExportCrmBatchHandler.php
@@ -11,7 +11,9 @@ use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\String\Slugger\SluggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler]
 final class ExportCrmBatchHandler extends AbstractCrmBatchHandler
 {
     private const ATTRIBUTES_TO_RETRIEVE = [

--- a/console/src/Search/Consumer/ExportCrmBatchHandler.php
+++ b/console/src/Search/Consumer/ExportCrmBatchHandler.php
@@ -9,9 +9,9 @@ use App\Repository\ProjectRepository;
 use App\Search\Model\BatchRequest;
 use OpenSpout\Writer\Common\Creator\WriterEntityFactory;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\String\Slugger\SluggerInterface;
-use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
 final class ExportCrmBatchHandler extends AbstractCrmBatchHandler

--- a/console/src/Search/Consumer/ReindexOrganizationCrmHandler.php
+++ b/console/src/Search/Consumer/ReindexOrganizationCrmHandler.php
@@ -4,9 +4,10 @@ namespace App\Search\Consumer;
 
 use App\Repository\OrganizationRepository;
 use App\Search\CrmIndexer;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class ReindexOrganizationCrmHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class ReindexOrganizationCrmHandler
 {
     public function __construct(private OrganizationRepository $repository, private CrmIndexer $crmIndexer)
     {

--- a/console/src/Search/Consumer/RemoveCmsDocumentHandler.php
+++ b/console/src/Search/Consumer/RemoveCmsDocumentHandler.php
@@ -3,8 +3,8 @@
 namespace App\Search\Consumer;
 
 use App\Search\CmsIndexer;
-use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Handler\Acknowledger;
 
 #[AsMessageHandler]
 final class RemoveCmsDocumentHandler

--- a/console/src/Search/Consumer/RemoveCmsDocumentHandler.php
+++ b/console/src/Search/Consumer/RemoveCmsDocumentHandler.php
@@ -4,9 +4,10 @@ namespace App\Search\Consumer;
 
 use App\Search\CmsIndexer;
 use Symfony\Component\Messenger\Handler\Acknowledger;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class RemoveCmsDocumentHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class RemoveCmsDocumentHandler
 {
     public function __construct(
         private readonly CmsIndexer $cmsIndexer,

--- a/console/src/Search/Consumer/RemoveCrmBatchHandler.php
+++ b/console/src/Search/Consumer/RemoveCrmBatchHandler.php
@@ -5,7 +5,9 @@ namespace App\Search\Consumer;
 use App\Repository\Community\ContactRepository;
 use App\Search\CrmIndexer;
 use App\Search\Model\BatchRequest;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler]
 final class RemoveCrmBatchHandler extends AbstractCrmBatchHandler
 {
     public function __construct(

--- a/console/src/Search/Consumer/RemoveCrmDocumentHandler.php
+++ b/console/src/Search/Consumer/RemoveCrmDocumentHandler.php
@@ -4,9 +4,10 @@ namespace App\Search\Consumer;
 
 use App\Bridge\Meilisearch\MeilisearchInterface;
 use App\Repository\OrganizationRepository;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class RemoveCrmDocumentHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class RemoveCrmDocumentHandler
 {
     public function __construct(private OrganizationRepository $repository, private MeilisearchInterface $meilisearch)
     {

--- a/console/src/Search/Consumer/RemoveTagCrmBatchHandler.php
+++ b/console/src/Search/Consumer/RemoveTagCrmBatchHandler.php
@@ -5,7 +5,9 @@ namespace App\Search\Consumer;
 use App\Repository\Community\TagRepository;
 use App\Search\CrmIndexer;
 use App\Search\Model\BatchRequest;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler]
 final class RemoveTagCrmBatchHandler extends AbstractCrmBatchHandler
 {
     public function __construct(

--- a/console/src/Search/Consumer/UpdateCmsDocumentHandler.php
+++ b/console/src/Search/Consumer/UpdateCmsDocumentHandler.php
@@ -5,8 +5,8 @@ namespace App\Search\Consumer;
 use App\Search\CmsIndexer;
 use App\Search\Model\Searchable;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Handler\Acknowledger;
 
 #[AsMessageHandler]
 final class UpdateCmsDocumentHandler

--- a/console/src/Search/Consumer/UpdateCmsDocumentHandler.php
+++ b/console/src/Search/Consumer/UpdateCmsDocumentHandler.php
@@ -6,9 +6,10 @@ use App\Search\CmsIndexer;
 use App\Search\Model\Searchable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Handler\Acknowledger;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class UpdateCmsDocumentHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class UpdateCmsDocumentHandler
 {
     public function __construct(
         private readonly EntityManagerInterface $em,

--- a/console/src/Search/Consumer/UpdateCrmDocumentHandler.php
+++ b/console/src/Search/Consumer/UpdateCrmDocumentHandler.php
@@ -4,9 +4,10 @@ namespace App\Search\Consumer;
 
 use App\Search\CrmIndexer;
 use Symfony\Component\Messenger\Handler\Acknowledger;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class UpdateCrmDocumentHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class UpdateCrmDocumentHandler
 {
     public function __construct(private CrmIndexer $crmIndexer)
     {

--- a/console/src/Search/Consumer/UpdateCrmDocumentHandler.php
+++ b/console/src/Search/Consumer/UpdateCrmDocumentHandler.php
@@ -3,8 +3,8 @@
 namespace App\Search\Consumer;
 
 use App\Search\CrmIndexer;
-use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Handler\Acknowledger;
 
 #[AsMessageHandler]
 final class UpdateCrmDocumentHandler

--- a/console/src/Theme/Consumer/SyncThemeHandler.php
+++ b/console/src/Theme/Consumer/SyncThemeHandler.php
@@ -13,9 +13,10 @@ use App\Theme\Source\ThemeManifestValidator;
 use App\Util\Json;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-final class SyncThemeHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class SyncThemeHandler
 {
     private EntityManagerInterface $em;
     private GithubInterface $github;

--- a/console/src/Validator/ContactUpdateToken.php
+++ b/console/src/Validator/ContactUpdateToken.php
@@ -10,11 +10,7 @@ class ContactUpdateToken extends Constraint
     public const TOKEN_EXPIRE = '8fe3cead-3ae1-4311-8cdd-ca76e8609d8d';
     public const INVALID_INSTANCE = 'f96fb6ac-3cea-4115-ace9-15187d983868';
 
-    protected static $errorNames = [
-        self::INVALID_INSTANCE => 'INVALID_INSTANCE',
-        self::INVALID_TOKEN => 'INVALID_TOKEN',
-        self::TOKEN_EXPIRE => 'TOKEN_EXPIRE',
-    ];
+    // Do not override Constraint::$errorNames (considered final in Symfony >=6.2)
 
     public string $message = 'Token invalid.';
     public ?string $token;

--- a/console/src/Validator/UniqueContactEmail.php
+++ b/console/src/Validator/UniqueContactEmail.php
@@ -9,9 +9,7 @@ class UniqueContactEmail extends Constraint
 {
     public const EMAIL_ALREADY_EXISTS = '7b7c5047-c924-4be4-beb5-213885a3b552';
 
-    protected static $errorNames = [
-        self::EMAIL_ALREADY_EXISTS => 'EMAIL_ALREADY_EXISTS',
-    ];
+    // Do not override Constraint::$errorNames (considered final in Symfony >=6.2)
 
     public function __construct(
         public readonly string $organizationField,
@@ -24,7 +22,7 @@ class UniqueContactEmail extends Constraint
         parent::__construct($options, $groups, $payload);
     }
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/console/src/Website/ImportExport/Parser/WordpressContentParser.php
+++ b/console/src/Website/ImportExport/Parser/WordpressContentParser.php
@@ -14,10 +14,9 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\String\Slugger\SluggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 use function Symfony\Component\String\u;
-
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class WordpressContentParser implements ExternalContentParserInterface
 {

--- a/console/translations/organization_community.en.yaml
+++ b/console/translations/organization_community.en.yaml
@@ -94,6 +94,19 @@ contacts:
             help: |
                 Custom fields are technical data fields that are used by your website to store
                 additional information regarding your contacts.
+        birth:
+            label: Birth information
+            name: Name
+            city: City
+            country: Country
+        recruited_by: Recruited by
+        mandates:
+            label: Mandates
+        commitments:
+            label: Commitments
+        payments:
+            label: Payments
+            help: Overview of known payments.
 
     create:
         page_title: Create a new contact
@@ -124,6 +137,11 @@ contacts:
             lastName: Last name
             birthdate: Birthdate
             gender: Gender
+            deceased: Deceased
+            birthName: Birth name
+            birthCity: Birth city
+            birthCountry: Birth country
+            recruitedBy: Recruited by
             nationality: Nationality
             company: Company
             jobTitle: Job title
@@ -152,8 +170,17 @@ contacts:
             facebook: Facebook profile URL
             twitter: X profile URL
             linkedIn: LinkedIn profile URL
+            instagram: Instagram profile URL
+            tikTok: TikTok profile URL or handle
+            bluesky: Bluesky profile URL
             telegram: Telegram account name
             whatsapp: Whatsapp phone number
+        mandates:
+            label: Mandates
+            help: Add, edit or remove contact mandates.
+        commitments:
+            label: Commitments
+            help: Add, edit or remove contact commitments.
         metadata:
             label: Subscription to communications
             all_projects: Global settings

--- a/console/translations/organization_community.fr.yaml
+++ b/console/translations/organization_community.fr.yaml
@@ -94,6 +94,19 @@ contacts:
             help: |
                 Les champs personnalisés sont des données additionelles stockées par votre site internet
                 sur vos contacts.
+        birth:
+            label: Informations de naissance
+            name: Nom
+            city: Ville
+            country: Pays
+        recruited_by: Recruté(e) par
+        mandates:
+            label: Mandats
+        commitments:
+            label: Engagements
+        payments:
+            label: Paiements
+            help: Aperçu des paiements connus.
 
     create:
         page_title: Créer un nouveau contact
@@ -124,6 +137,11 @@ contacts:
             lastName: Nom
             birthdate: Date de naissance
             gender: Genre
+            deceased: Décédé(e)
+            birthName: Nom de naissance
+            birthCity: Ville de naissance
+            birthCountry: Pays de naissance
+            recruitedBy: Recruté(e) par
             nationality: Nationalité
             company: Entreprise
             jobTitle: Poste
@@ -152,8 +170,17 @@ contacts:
             facebook: URL du profil Facebook
             twitter: URL du profil X
             linkedIn: URL du profil LinkedIn
+            instagram: URL du profil Instagram
+            tikTok: URL ou identifiant TikTok
+            bluesky: URL du profil Bluesky
             telegram: Nom d'utilisateur Telegram
             whatsapp: Numéro de téléphone Whatsapp
+        mandates:
+            label: Mandats
+            help: Ajouter, modifier ou supprimer les mandats du contact.
+        commitments:
+            label: Engagements
+            help: Ajouter, modifier ou supprimer les engagements du contact.
         metadata:
             label: Inscription aux communications
             all_projects: Préférences générales

--- a/console/translations/project_contacts.en.yaml
+++ b/console/translations/project_contacts.en.yaml
@@ -29,6 +29,13 @@ view:
             label: 'Phone calls:'
             subscribed: Accepted
             unsubscribed: Refused
+        deceased: Deceased
+        birth:
+            label: Birth information
+            name: Name
+            city: City
+            country: Country
+        recruited_by: Recruited by
         email: Email address
         additional_emails: Additional email addresses
         name: Full name
@@ -81,6 +88,11 @@ form:
         lastName: Last name
         birthdate: Birthdate
         gender: Gender
+        deceased: Deceased
+        birthName: Birth name
+        birthCity: Birth city
+        birthCountry: Birth country
+        recruitedBy: Recruited by
         company: Company
         jobTitle: Job title
     tags:
@@ -108,8 +120,17 @@ form:
         facebook: Facebook profile URL
         twitter: X profile URL
         linkedIn: LinkedIn profile URL
+        instagram: Instagram profile URL
+        tikTok: TikTok profile URL or handle
+        bluesky: Bluesky profile URL
         telegram: Telegram account name
         whatsapp: Whatsapp account name
+    mandates:
+        label: Mandates
+        help: Add, edit or remove contact mandates.
+    commitments:
+        label: Commitments
+        help: Add, edit or remove contact commitments.
     metadata:
         comment: Internal note
         commentHelp: |

--- a/console/translations/project_contacts.fr.yaml
+++ b/console/translations/project_contacts.fr.yaml
@@ -29,6 +29,13 @@ view:
             label: 'Appels :'
             subscribed: Acceptés
             unsubscribed: Refusés
+        deceased: Décédé(e)
+        birth:
+            label: Informations de naissance
+            name: Nom
+            city: Ville
+            country: Pays
+        recruited_by: Recruté(e) par
         email: Email
         additional_emails: Emails additionels
         name: Nom complet
@@ -81,6 +88,11 @@ form:
         lastName: Nom
         birthdate: Date de naissance
         gender: Genre
+        deceased: Décédé(e)
+        birthName: Nom de naissance
+        birthCity: Ville de naissance
+        birthCountry: Pays de naissance
+        recruitedBy: Recruté(e) par
         company: Entreprise
         jobTitle: Poste
     tags:
@@ -108,8 +120,17 @@ form:
         facebook: URL du profil Facebook
         twitter: URL du profil X
         linkedIn: URL du profil LinkedIn
+        instagram: URL du profil Instagram
+        tikTok: URL ou identifiant TikTok
+        bluesky: URL du profil Bluesky
         telegram: Nom d'utilisateur Telegram
         whatsapp: Numéro de téléphone Whatsapp
+    mandates:
+        label: Mandats
+        help: Ajouter, modifier ou supprimer les mandats du contact.
+    commitments:
+        label: Engagements
+        help: Ajouter, modifier ou supprimer les engagements du contact.
     metadata:
         comment: Note interne
         commentHelp: |


### PR DESCRIPTION
This PR fixes Symfony Messenger and Validator deprecations observed on 2025-09-09.\n\nChanges:\n- Replaced deprecated MessageHandlerInterface implementations with #[AsMessageHandler] attributes across all handlers.\n- Removed overrides of Constraint:: in ContactUpdateToken and UniqueContactEmail.\n- Added native return type (string|array) to UniqueContactEmail::getTargets().\n\nThis silences deprecations and prepares for Symfony 7.\n\nPlease run the console test suite to validate end-to-end: `docker compose exec console bin/phpunit`.
